### PR TITLE
Updating the items file import process

### DIFF
--- a/sources/import.queries.php
+++ b/sources/import.queries.php
@@ -160,19 +160,20 @@ switch (filter_input(INPUT_POST, 'type', FILTER_SANITIZE_FULL_SPECIAL_CHARS)) {
         if ($fp = fopen($file, 'r')) {
             // data from CSV
             $valuesToImport = array();
-
+            $header = fgetcsv($fp);
             // Lexer configuration
             $config = new LexerConfig();
             $lexer = new Lexer($config);
             $config->setIgnoreHeaderLine('true');
             $interpreter = new Interpreter();
-            $interpreter->addObserver(function (array $row) use (&$valuesToImport) {
+            $interpreter->addObserver(function (array $row) use (&$valuesToImport,$header) {
+                $rowData = array_combine($header, $row);
                 $valuesToImport[] = array(
-                    'Label' => $row[0],
-                    'Login' => $row[1],
-                    'Password' => $row[2],
-                    'url' => $row[3],
-                    'Comments' => $row[4],
+                    'Label' => $rowData['label'],
+                    'Login' => $rowData['login'],
+                    'Password' => $rowData['pw'],
+                    'url' => $rowData['url'],
+                    'Comments' => $rowData['description'],
                 );
             });
             $lexer->parse($file, $interpreter);


### PR DESCRIPTION
The exported items file can be used directly for importing, and the contents are confirmed according to the table header, but no longer according to the serial number of the column.